### PR TITLE
Remove extra space when "description" of /cventry is empty

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -649,7 +649,9 @@
       {\entrypositionstyle{#1} & \entrydatestyle{#4} \\}
       {\entrytitlestyle{#2} & \entrylocationstyle{#3} \\
       \entrypositionstyle{#1} & \entrydatestyle{#4} \\}
-    \multicolumn{2}{L{\textwidth}}{\descriptionstyle{#5}}
+    \ifstrempty{#5}
+      {}
+      {\multicolumn{2}{L{\textwidth}}{\descriptionstyle{#5}} \\}
   \end{tabular*}%
 }
 


### PR DESCRIPTION
This simply checks if the description is empty and if it is, it renders nothing.